### PR TITLE
Updated DumpJob to create empty folders for znodes without any data.

### DIFF
--- a/src/main/java/com/d2fn/guano/DumpJob.java
+++ b/src/main/java/com/d2fn/guano/DumpJob.java
@@ -65,8 +65,12 @@ public class DumpJob implements Job, Watcher {
 
             // ensure parent dir is created
             File f = new File(outputPath);
-            boolean s = f.mkdirs();
-
+            if(!f.exists() ) {
+                boolean s = f.mkdirs();
+                if (s) {
+                    System.out.println("Created folder: " + outputPath);
+                }
+            }
             // this znode is a dir, so ensure the directory is created and build a __znode value in its dir
             writeZnode(zk, outputPath + "/_znode", currznode);
 
@@ -92,6 +96,18 @@ public class DumpJob implements Job, Watcher {
                 out.flush();
                 out.close();
             }
+        } else {
+            if (!outFile.contains("_znode") && stat.getEphemeralOwner() == 0) {
+                // Create an empty folder for Ephemeral nodes.
+                File f = new File(outFile);
+                if(!f.exists() ) {
+                    boolean s = f.mkdirs();
+                    if (s) {
+                        System.out.println("Created Empty folder: " + outFile);
+                    }
+                }
+            }
+
         }
     }
 

--- a/src/main/java/com/d2fn/guano/DumpJob.java
+++ b/src/main/java/com/d2fn/guano/DumpJob.java
@@ -64,13 +64,8 @@ public class DumpJob implements Job, Watcher {
         if(!children.isEmpty()) {
 
             // ensure parent dir is created
-            File f = new File(outputPath);
-            if(!f.exists() ) {
-                boolean s = f.mkdirs();
-                if (s) {
-                    System.out.println("Created folder: " + outputPath);
-                }
-            }
+            createFolder(outputPath);
+
             // this znode is a dir, so ensure the directory is created and build a __znode value in its dir
             writeZnode(zk, outputPath + "/_znode", currznode);
 
@@ -98,17 +93,22 @@ public class DumpJob implements Job, Watcher {
             }
         } else {
             if (!outFile.contains("_znode") && stat.getEphemeralOwner() == 0) {
-                // Create an empty folder for Ephemeral nodes.
-                File f = new File(outFile);
-                if(!f.exists() ) {
-                    boolean s = f.mkdirs();
-                    if (s) {
-                        System.out.println("Created Empty folder: " + outFile);
-                    }
-                }
+                // Create an empty folder for Permanent nodes.
+                createFolder(outFile);
             }
 
         }
+    }
+
+    private void createFolder(String path) {
+        File f = new File(path);
+        if(!f.exists() ) {
+            boolean s = f.mkdirs();
+            if (s) {
+                System.out.println("Created folder: " + path);
+            }
+        }
+
     }
 
     @Override


### PR DESCRIPTION
Hi,
I've been using Guano to make backup copies of a ZooKeeper hierearchy and found that empty znodes where missed from the directory structure created. I'd like to persist these so have added a little extra code to create empty folders.
Please consider my change for including in Guano?

Kind regards

Steve
